### PR TITLE
Apply brand palette and layout changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
   </head>
 
   <body>

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,12 +1,11 @@
 
-import { User, Award, BookOpen, Users } from 'lucide-react';
+import { User, BookOpen, Users } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 
 const About = () => {
   const stats = [
     { icon: Users, label: "Newsletter Subscribers", value: "50,000+" },
     { icon: BookOpen, label: "Articles Published", value: "200+" },
-    { icon: Award, label: "Industry Recognition", value: "15+" },
     { icon: User, label: "Years in AI", value: "8+" }
   ];
 
@@ -17,7 +16,7 @@ const About = () => {
           <div className="text-center mb-16">
             <h2 className="text-4xl md:text-5xl font-bold mb-6">
               About{' '}
-              <span className="bg-gradient-to-r from-blue-500 to-purple-600 bg-clip-text text-transparent">
+              <span className="bg-gradient-to-r from-[#F59E0B] to-[#14B8A6] bg-clip-text text-transparent">
                 The NextTech Brief
               </span>
             </h2>
@@ -48,8 +47,8 @@ const About = () => {
             </div>
 
             <div className="relative">
-              <div className="w-full h-80 bg-gradient-to-br from-blue-500/10 to-purple-600/10 rounded-2xl border border-border flex items-center justify-center">
-                <div className="w-32 h-32 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center">
+              <div className="w-full h-80 bg-gradient-to-br from-[#F59E0B]/10 to-[#14B8A6]/10 rounded-2xl border border-border flex items-center justify-center">
+                <div className="w-32 h-32 bg-gradient-to-br from-[#F59E0B] to-[#14B8A6] rounded-full flex items-center justify-center">
                   <User className="w-16 h-16 text-white" />
                 </div>
               </div>
@@ -59,11 +58,11 @@ const About = () => {
             </div>
           </div>
 
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 place-items-center">
             {stats.map((stat, index) => (
               <Card key={index} className="text-center hover:shadow-lg transition-shadow">
-                <CardContent className="pt-6">
-                  <div className="w-12 h-12 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center mx-auto mb-4">
+                <CardContent className="pt-6 flex flex-col items-center justify-center">
+                  <div className="w-12 h-12 bg-gradient-to-br from-[#F59E0B] to-[#14B8A6] rounded-lg flex items-center justify-center mx-auto mb-4">
                     <stat.icon className="w-6 h-6 text-white" />
                   </div>
                   <div className="text-2xl font-bold text-foreground mb-2">{stat.value}</div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -23,7 +23,7 @@ const Footer = () => {
           <div className="lg:col-span-2">
             <div className="flex items-center space-x-2 mb-4">
               <img src="/logo.svg" alt="NextTech Brief logo" className="w-8 h-8" />
-              <span className="text-xl font-bold bg-gradient-to-r from-blue-500 to-purple-600 bg-clip-text text-transparent">
+              <span className="text-xl font-bold bg-gradient-to-r from-[#F59E0B] to-[#14B8A6] bg-clip-text text-transparent">
                 The NextTech Brief
               </span>
             </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -10,13 +10,17 @@ const Footer = () => {
   ];
 
   const footerLinks = {
-    Newsletter: ["Latest Issue", "Archive", "Subscribe"],
-    Company: ["About"],
-    Resources: ["Tools"]
+    Newsletter: [
+      { label: "Latest Issue", href: "#newsletter" },
+      { label: "Archive", href: "#newsletter" },
+      { label: "Subscribe", href: "#subscribe" }
+    ],
+    Company: [{ label: "About", href: "#about" }],
+    Resources: [{ label: "Tools", href: "#about" }]
   };
 
   return (
-    <footer className="bg-muted/50 border-t border-border">
+    <footer className="bg-muted/50 border-t border-border text-[#121212]">
       <div className="container mx-auto px-4 py-12">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-8 mb-8">
           {/* Brand Section */}
@@ -50,15 +54,15 @@ const Footer = () => {
           {/* Footer Links */}
           {Object.entries(footerLinks).map(([category, links]) => (
             <div key={category}>
-              <h3 className="font-semibold text-foreground mb-4">{category}</h3>
+              <h3 className="font-semibold mb-4">{category}</h3>
               <ul className="space-y-2">
                 {links.map((link, index) => (
                   <li key={index}>
                     <a
-                      href="#"
+                      href={link.href}
                       className="text-muted-foreground hover:text-primary transition-colors"
                     >
-                      {link}
+                      {link.label}
                     </a>
                   </li>
                 ))}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,7 +20,7 @@ const Header = () => {
           {/* Logo */}
           <div className="flex items-center space-x-2">
             <img src="/logo.svg" alt="NextTech Brief logo" className="w-8 h-8" />
-            <span className="text-xl font-bold bg-gradient-to-r from-blue-500 to-purple-600 bg-clip-text text-transparent">
+            <span className="text-xl font-bold bg-gradient-to-r from-[#F59E0B] to-[#14B8A6] bg-clip-text text-transparent">
               The NextTech Brief
             </span>
           </div>
@@ -36,8 +36,8 @@ const Header = () => {
             <a href="#about" className="text-foreground hover:text-primary transition-colors">
               About
             </a>
-            <Button 
-              className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
+            <Button
+              className="bg-gradient-to-r from-[#F59E0B] to-[#14B8A6] hover:opacity-90"
               onClick={scrollToSubscribe}
             >
               Subscribe
@@ -66,8 +66,8 @@ const Header = () => {
               <a href="#about" className="text-foreground hover:text-primary transition-colors">
                 About
               </a>
-              <Button 
-                className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 w-full"
+              <Button
+                className="bg-gradient-to-r from-[#F59E0B] to-[#14B8A6] hover:opacity-90 w-full"
                 onClick={scrollToSubscribe}
               >
                 Subscribe

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -21,22 +21,22 @@ const Hero = () => {
     <section id="home" className="min-h-screen flex items-center justify-center relative overflow-hidden bg-gradient-to-br from-background via-background to-muted/20">
       {/* Animated Background Elements */}
       <div className="absolute inset-0 overflow-hidden">
-        <div className="absolute top-1/4 left-1/4 w-64 h-64 bg-gradient-to-r from-blue-500/10 to-purple-600/10 rounded-full blur-3xl animate-pulse"></div>
-        <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-gradient-to-r from-purple-500/10 to-pink-600/10 rounded-full blur-3xl animate-pulse delay-1000"></div>
+        <div className="absolute top-1/4 left-1/4 w-64 h-64 bg-gradient-to-r from-[#F59E0B]/10 to-[#14B8A6]/10 rounded-full blur-3xl animate-pulse"></div>
+        <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-gradient-to-r from-[#14B8A6]/10 to-[#F59E0B]/10 rounded-full blur-3xl animate-pulse delay-1000"></div>
       </div>
 
       <div className="container mx-auto px-4 text-center relative z-10">
         <div className="max-w-4xl mx-auto">
           {/* Badge */}
-          <div className="inline-flex items-center space-x-2 bg-gradient-to-r from-blue-500/10 to-purple-600/10 border border-blue-500/20 rounded-full px-4 py-2 mb-8">
-            <Sparkles className="w-4 h-4 text-blue-500" />
+          <div className="inline-flex items-center space-x-2 bg-gradient-to-r from-[#F59E0B]/10 to-[#14B8A6]/10 border border-[#F59E0B]/20 rounded-full px-4 py-2 mb-8">
+            <Sparkles className="w-4 h-4 text-[#F59E0B]" />
             <span className="text-sm font-medium text-foreground">Weekly AI Insights & Analysis</span>
           </div>
 
           {/* Main Headline */}
           <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
             Stay Ahead in the{' '}
-            <span className="bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 bg-clip-text text-transparent">
+            <span className="bg-gradient-to-r from-[#F59E0B] to-[#14B8A6] bg-clip-text text-transparent">
               AI Revolution
             </span>
           </h1>
@@ -49,46 +49,26 @@ const Hero = () => {
 
           {/* CTA Buttons */}
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-12">
-            <Button 
-              size="lg" 
-              className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white px-8 py-4 text-lg group"
+            <Button
+              size="lg"
+              className="bg-gradient-to-r from-[#F59E0B] to-[#14B8A6] hover:opacity-90 text-white px-8 py-4 text-lg group"
               onClick={scrollToSubscribe}
             >
               Subscribe Now
               <ArrowRight className="ml-2 w-5 h-5 group-hover:translate-x-1 transition-transform" />
             </Button>
-            <Button 
-              variant="outline" 
-              size="lg" 
+            <Button
+              variant="outline"
+              size="lg"
               className="border-border hover:bg-muted px-8 py-4 text-lg"
               onClick={scrollToNewsletter}
             >
               Read Latest Issue
             </Button>
           </div>
-
-          {/* Stats */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-2xl mx-auto">
-            <div className="text-center">
-              <div className="text-3xl font-bold text-foreground mb-2">50K+</div>
-              <div className="text-muted-foreground">Subscribers</div>
-            </div>
-            <div className="text-center">
-              <div className="text-3xl font-bold text-foreground mb-2">200+</div>
-              <div className="text-muted-foreground">Issues Published</div>
-            </div>
-            <div className="text-center">
-              <div className="text-3xl font-bold text-foreground mb-2">98%</div>
-              <div className="text-muted-foreground">Open Rate</div>
-            </div>
-          </div>
         </div>
       </div>
 
-      {/* Floating Brain Icon */}
-      <div className="absolute top-20 right-20 hidden lg:block animate-bounce">
-        <Brain className="w-12 h-12 text-blue-500/30" />
-      </div>
     </section>
   );
 };

--- a/src/components/Newsletter.tsx
+++ b/src/components/Newsletter.tsx
@@ -36,7 +36,7 @@ const Newsletter = () => {
   ];
 
   return (
-    <section id="newsletter" className="py-20 bg-muted/30">
+    <section id="newsletter" className="py-20 bg-muted/30 text-[#121212]">
       <div className="container mx-auto px-4">
         <div className="text-center mb-16">
           <h2 className="text-4xl md:text-5xl font-bold mb-6">

--- a/src/components/Newsletter.tsx
+++ b/src/components/Newsletter.tsx
@@ -13,7 +13,7 @@ const Newsletter = () => {
       date: "Dec 5, 2024",
       category: "LLMs",
       icon: Cpu,
-      gradient: "from-blue-500 to-cyan-500"
+      gradient: "from-[#F59E0B] to-[#14B8A6]"
     },
     {
       title: "The Rise of AI Agents: Autonomous Intelligence in Action",
@@ -22,7 +22,7 @@ const Newsletter = () => {
       date: "Dec 3, 2024",
       category: "AI Agents",
       icon: TrendingUp,
-      gradient: "from-purple-500 to-pink-500"
+      gradient: "from-[#14B8A6] to-[#F59E0B]"
     },
     {
       title: "Prompt Engineering Mastery: Advanced Techniques",
@@ -31,7 +31,7 @@ const Newsletter = () => {
       date: "Nov 28, 2024",
       category: "Techniques",
       icon: Lightbulb,
-      gradient: "from-green-500 to-emerald-500"
+      gradient: "from-[#F59E0B] to-[#14B8A6]"
     }
   ];
 
@@ -41,7 +41,7 @@ const Newsletter = () => {
         <div className="text-center mb-16">
           <h2 className="text-4xl md:text-5xl font-bold mb-6">
             Latest from{' '}
-            <span className="bg-gradient-to-r from-blue-500 to-purple-600 bg-clip-text text-transparent">
+            <span className="bg-gradient-to-r from-[#F59E0B] to-[#14B8A6] bg-clip-text text-transparent">
               The NextTech Brief
             </span>
           </h2>

--- a/src/components/Subscribe.tsx
+++ b/src/components/Subscribe.tsx
@@ -68,12 +68,11 @@ const Subscribe = () => {
     "Weekly AI research summaries",
     "Exclusive industry insights",
     "Early access to new tools",
-    "Expert interviews & analysis",
     "No spam, unsubscribe anytime"
   ];
 
   return (
-    <section id="subscribe" className="py-20 bg-gradient-to-br from-[#F59E0B]/10 via-[#14B8A6]/10 to-[#F59E0B]/10">
+    <section id="subscribe" className="py-20 bg-gradient-to-br from-[#121212] via-[#1E1E1E] to-[#121212] text-white">
       <div className="container mx-auto px-4">
         <div className="max-w-4xl mx-auto">
           <Card className="border-2 border-gradient-to-r from-[#F59E0B]/20 to-[#14B8A6]/20 bg-card/90 backdrop-blur-sm">
@@ -81,7 +80,7 @@ const Subscribe = () => {
               <div className="text-center mb-8">
                 <div className="inline-flex items-center space-x-2 bg-gradient-to-r from-[#F59E0B]/10 to-[#14B8A6]/10 border border-[#F59E0B]/20 rounded-full px-4 py-2 mb-6">
                   <Sparkles className="w-4 h-4 text-[#F59E0B]" />
-                  <span className="text-sm font-medium">Join 50,000+ AI Enthusiasts</span>
+                  <span className="text-sm font-medium">Join AI Enthusiasts</span>
                 </div>
                 
                 <h2 className="text-3xl md:text-4xl font-bold mb-4">
@@ -106,7 +105,7 @@ const Subscribe = () => {
                         placeholder="Enter your email address"
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
-                        className="pl-10 py-6 text-base border-border focus:border-primary"
+                        className="pl-10 py-6 text-base border-border bg-[#1E1E1E] text-white placeholder:text-muted-foreground focus:border-[#14B8A6] transition-colors"
                         required
                         disabled={isLoading}
                       />
@@ -114,7 +113,7 @@ const Subscribe = () => {
                     <Button
                       type="submit"
                       size="lg"
-                      className="bg-gradient-to-r from-[#F59E0B] to-[#14B8A6] hover:opacity-90 py-6 px-8 text-base font-semibold"
+                      className="bg-gradient-to-r from-[#F59E0B] to-[#14B8A6] hover:bg-[#F59E0B] hover:from-[#F59E0B] hover:to-[#F59E0B] focus:ring-2 focus:ring-[#14B8A6] transition-colors py-6 px-8 text-base font-semibold"
                       disabled={isLoading}
                     >
                       {isLoading ? 'Subscribing...' : 'Subscribe Free'}

--- a/src/components/Subscribe.tsx
+++ b/src/components/Subscribe.tsx
@@ -73,20 +73,20 @@ const Subscribe = () => {
   ];
 
   return (
-    <section id="subscribe" className="py-20 bg-gradient-to-br from-blue-50/50 via-purple-50/30 to-pink-50/50 dark:from-blue-950/20 dark:via-purple-950/20 dark:to-pink-950/20">
+    <section id="subscribe" className="py-20 bg-gradient-to-br from-[#F59E0B]/10 via-[#14B8A6]/10 to-[#F59E0B]/10">
       <div className="container mx-auto px-4">
         <div className="max-w-4xl mx-auto">
-          <Card className="border-2 border-gradient-to-r from-blue-500/20 to-purple-600/20 bg-card/90 backdrop-blur-sm">
+          <Card className="border-2 border-gradient-to-r from-[#F59E0B]/20 to-[#14B8A6]/20 bg-card/90 backdrop-blur-sm">
             <CardContent className="p-8 md:p-12">
               <div className="text-center mb-8">
-                <div className="inline-flex items-center space-x-2 bg-gradient-to-r from-blue-500/10 to-purple-600/10 border border-blue-500/20 rounded-full px-4 py-2 mb-6">
-                  <Sparkles className="w-4 h-4 text-blue-500" />
+                <div className="inline-flex items-center space-x-2 bg-gradient-to-r from-[#F59E0B]/10 to-[#14B8A6]/10 border border-[#F59E0B]/20 rounded-full px-4 py-2 mb-6">
+                  <Sparkles className="w-4 h-4 text-[#F59E0B]" />
                   <span className="text-sm font-medium">Join 50,000+ AI Enthusiasts</span>
                 </div>
                 
                 <h2 className="text-3xl md:text-4xl font-bold mb-4">
                   Never Miss an{' '}
-                  <span className="bg-gradient-to-r from-blue-500 to-purple-600 bg-clip-text text-transparent">
+                  <span className="bg-gradient-to-r from-[#F59E0B] to-[#14B8A6] bg-clip-text text-transparent">
                     AI Breakthrough
                   </span>
                 </h2>
@@ -111,10 +111,10 @@ const Subscribe = () => {
                         disabled={isLoading}
                       />
                     </div>
-                    <Button 
+                    <Button
                       type="submit"
                       size="lg"
-                      className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 py-6 px-8 text-base font-semibold"
+                      className="bg-gradient-to-r from-[#F59E0B] to-[#14B8A6] hover:opacity-90 py-6 px-8 text-base font-semibold"
                       disabled={isLoading}
                     >
                       {isLoading ? 'Subscribing...' : 'Subscribe Free'}

--- a/src/index.css
+++ b/src/index.css
@@ -6,33 +6,33 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --background: 0 0% 7%;
+    --foreground: 0 0% 100%;
 
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card: 220 14% 96%;
+    --card-foreground: 0 0% 7%;
 
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
+    --popover: 220 14% 96%;
+    --popover-foreground: 0 0% 7%;
 
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
+    --primary: 38 92% 50%;
+    --primary-foreground: 0 0% 100%;
 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 173 80% 40%;
+    --secondary-foreground: 0 0% 100%;
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted: 0 0% 88%;
+    --muted-foreground: 0 0% 20%;
 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 173 80% 40%;
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive-foreground: 0 0% 100%;
 
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --border: 0 0% 20%;
+    --input: 0 0% 20%;
+    --ring: 38 92% 50%;
 
     --radius: 0.5rem;
 
@@ -54,41 +54,41 @@
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
+    --background: 0 0% 7%;
+    --foreground: 0 0% 100%;
 
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
+    --card: 220 14% 96%;
+    --card-foreground: 0 0% 7%;
 
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
+    --popover: 220 14% 96%;
+    --popover-foreground: 0 0% 7%;
 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 38 92% 50%;
+    --primary-foreground: 0 0% 100%;
 
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
+    --secondary: 173 80% 40%;
+    --secondary-foreground: 0 0% 100%;
 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
+    --muted: 0 0% 88%;
+    --muted-foreground: 0 0% 20%;
 
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --accent: 173 80% 40%;
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive-foreground: 0 0% 100%;
 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
+    --border: 0 0% 20%;
+    --input: 0 0% 20%;
+    --ring: 38 92% 50%;
+    --sidebar-background: 0 0% 7%;
+    --sidebar-foreground: 0 0% 100%;
+    --sidebar-primary: 38 92% 50%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-accent: 173 80% 40%;
+    --sidebar-accent-foreground: 0 0% 100%;
+    --sidebar-border: 0 0% 20%;
+    --sidebar-ring: 38 92% 50%;
   }
 }
 
@@ -98,6 +98,6 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -100,4 +100,9 @@
   body {
     @apply bg-background text-foreground font-sans;
   }
+
+  html {
+    scroll-behavior: smooth;
+  }
 }
+

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -10,10 +10,12 @@ const Index = () => {
   return (
     <div className="min-h-screen">
       <Header />
-      <Hero />
-      <Newsletter />
-      <Subscribe />
-      <About />
+      <main>
+        <Hero />
+        <Newsletter />
+        <Subscribe />
+        <About />
+      </main>
       <Footer />
     </div>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,8 +18,11 @@ export default {
 				'2xl': '1400px'
 			}
 		},
-		extend: {
-			colors: {
+                extend: {
+                        fontFamily: {
+                                sans: ["Inter", "sans-serif"],
+                        },
+                        colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',
 				ring: 'hsl(var(--ring))',


### PR DESCRIPTION
## Summary
- update hero section styling and remove marketing stats/brain icon
- center stats in About section and tweak colors
- refresh gradient colors across footer, header, newsletter and subscribe sections
- switch site color palette to new dark brand scheme
- add Google font and configure Inter as default

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846c3b401448322911685cca8f9f632